### PR TITLE
Add order status fields to table

### DIFF
--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -30,7 +30,10 @@ class Order extends Model
         'paymentReference',
         'notes',
         'paymentStatus',
-        'deleteStatus'
+        'deleteStatus',
+        'leadershipStatus',
+        'chaqueMatchStatus',
+        'taxStatus'
     ];
 
     protected $casts = [

--- a/database/migrations/2025_10_02_000000_add_status_fields_to_orders_table.php
+++ b/database/migrations/2025_10_02_000000_add_status_fields_to_orders_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->tinyInteger('leadershipStatus')->default(0)->after('deleteStatus')->comment('1 - done, 0 - not done');
+            $table->tinyInteger('chaqueMatchStatus')->default(0)->after('leadershipStatus')->comment('1 - done, 0 - not done');
+            $table->tinyInteger('taxStatus')->default(0)->after('chaqueMatchStatus')->comment('1 - done, 0 - not done');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('orders', function (Blueprint $table) {
+            $table->dropColumn(['leadershipStatus', 'chaqueMatchStatus', 'taxStatus']);
+        });
+    }
+};


### PR DESCRIPTION
Add `leadershipStatus`, `chaqueMatchStatus`, and `taxStatus` fields to the `orders` table and `Order` model to track order processing statuses.

---
<a href="https://cursor.com/background-agent?bcId=bc-92d07e0f-7a9a-4472-9003-6e1c46482f5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-92d07e0f-7a9a-4472-9003-6e1c46482f5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

