### PR TITLE
Create and document leadership chaque match cron

### DIFF
--- a/CRON_DOCUMENTATION.md
+++ b/CRON_DOCUMENTATION.md
@@ -34,11 +34,33 @@ This document lists all current and planned cron jobs for the Serve Cafe applica
 -   **Description**: Returns the most recent active package information
 -   **Output**: JSON response with package details
 
+### 3. Leadership Chaque Match Processing
+
+-   **Route**: `/cron/leadership-chaque-match`
+-   **Method**: GET
+-   **Controller**: `CronController@cronLeadershipChaqueMatch`
+-   **Purpose**: Process leadership chaque match for eligible orders
+-   **Frequency**: Daily (recommended)
+-   **Description**:
+    -   Fetches orders from `orders` table with specific criteria:
+        -   `customerType` = 'member'
+        -   `free_paid_member_status` = 1
+        -   `paymentStatus` = 1
+        -   `leadership_status` = 0
+        -   `chaque_match_status` = 0
+        -   `tax_status` = 0
+        -   `deleteStatus` = 0 (exclude deleted records)
+    -   Orders by ID in ascending order for consistent processing
+    -   Provides placeholder for future processing logic (commission calculations, status updates, etc.)
+    -   Logs execution details for monitoring and debugging
+-   **Output**: JSON response with processed order details and execution statistics
+-   **Note**: Requires additional fields in orders table: `free_paid_member_status`, `leadership_status`, `chaque_match_status`, `tax_status`
+
 ---
 
 ## Planned Future Cron Jobs
 
-### 3. Daily Transaction Processing
+### 4. Daily Transaction Processing
 
 -   **Route**: `/cron/process-daily-transactions`
 -   **Method**: GET
@@ -52,7 +74,7 @@ This document lists all current and planned cron jobs for the Serve Cafe applica
     -   Generate transaction reports
     -   Send notifications for completed transactions
 
-### 4. Commission Calculation
+### 5. Commission Calculation
 
 -   **Route**: `/cron/calculate-commissions`
 -   **Method**: GET
@@ -66,7 +88,7 @@ This document lists all current and planned cron jobs for the Serve Cafe applica
     -   Distribute earnings to upline members
     -   Generate commission reports
 
-### 5. Package Expiry Check
+### 6. Package Expiry Check
 
 -   **Route**: `/cron/check-package-expiry`
 -   **Method**: GET
@@ -80,7 +102,7 @@ This document lists all current and planned cron jobs for the Serve Cafe applica
     -   Downgrade expired packages
     -   Update member status
 
-### 6. Wallet Balance Sync
+### 7. Wallet Balance Sync
 
 -   **Route**: `/cron/sync-wallet-balances`
 -   **Method**: GET
@@ -94,7 +116,7 @@ This document lists all current and planned cron jobs for the Serve Cafe applica
     -   Update wallet records
     -   Generate balance reports
 
-### 7. Order Status Updates
+### 8. Order Status Updates
 
 -   **Route**: `/cron/update-order-status`
 -   **Method**: GET
@@ -136,7 +158,7 @@ This document lists all current and planned cron jobs for the Serve Cafe applica
     -   Optimize database tables
     -   Archive old records
 
-### 10. Backup Generation
+### 11. Backup Generation
 
 -   **Route**: `/cron/generate-backup`
 -   **Method**: GET
@@ -162,6 +184,9 @@ Add the following entries to your server's crontab:
 # Serve Cafe Cron Jobs
 # Activate Member Package - Daily at 1 AM
 0 1 * * * curl -s http://localhost:8000/cron/activate-member-package
+
+# Leadership Chaque Match Processing - Daily at 1:30 AM
+30 1 * * * curl -s http://localhost:8000/cron/leadership-chaque-match
 
 # Process Daily Transactions - Every 6 hours
 0 */6 * * * curl -s http://localhost:8000/cron/process-daily-transactions
@@ -254,6 +279,7 @@ Test each cron job manually by visiting the route in your browser:
 
 ```
 http://localhost:8000/cron/activate-member-package
+http://localhost:8000/cron/leadership-chaque-match
 ```
 
 ### Automated Testing

--- a/app/Http/Controllers/CronController.php
+++ b/app/Http/Controllers/CronController.php
@@ -713,6 +713,84 @@ class CronController extends Controller
     }
 
     /**
+     * Cron job to process leadership chaque match
+     * Fetches orders from orders table with specific criteria
+     */
+    public function cronLeadershipChaqueMatch()
+    {
+        try {
+            // Note: The following fields need to be added to the orders table structure:
+            // - free_paid_member_status (tinyInteger)
+            // - leadership_status (tinyInteger)  
+            // - chaque_match_status (tinyInteger)
+            // - tax_status (tinyInteger)
+            
+            // Fetch orders with specified conditions
+            $orders = DB::table('orders')
+                ->where('customerType', 'member')
+                ->where('free_paid_member_status', 1)
+                ->where('paymentStatus', 1)
+                ->where('leadership_status', 0)
+                ->where('chaque_match_status', 0)
+                ->where('tax_status', 0)
+                ->where('deleteStatus', 0) // Exclude deleted records
+                ->orderBy('id', 'asc') // Order by ID ascending
+                ->get();
+
+            // Log the cron job execution
+            Log::info('Leadership Chaque Match Cron executed', [
+                'total_orders_found' => $orders->count(),
+                'execution_time' => now()->toDateTimeString()
+            ]);
+
+            // Process each order (placeholder for future processing logic)
+            $processedOrders = [];
+            foreach ($orders as $order) {
+                // Add your processing logic here
+                // For example:
+                // - Update leadership_status
+                // - Update chaque_match_status
+                // - Process commissions
+                // - Create related records
+                
+                $processedOrders[] = [
+                    'order_id' => $order->id,
+                    'customer_type' => $order->customerType,
+                    'member_user_id' => $order->memberUserId,
+                    'payment_status' => $order->paymentStatus,
+                    'order_total' => $order->sellingPrice ?? 0,
+                    'processed_at' => now()->toDateTimeString()
+                ];
+            }
+
+            return response()->json([
+                'success' => true,
+                'message' => 'Leadership Chaque Match cron job executed successfully',
+                'data' => [
+                    'total_orders_found' => $orders->count(),
+                    'processed_orders_count' => count($processedOrders),
+                    'processed_orders' => $processedOrders,
+                    'execution_timestamp' => now()->toDateTimeString()
+                ]
+            ]);
+
+        } catch (\Exception $e) {
+            // Log the error
+            Log::error('Leadership Chaque Match Cron job failed', [
+                'error' => $e->getMessage(),
+                'trace' => $e->getTraceAsString(),
+                'execution_time' => now()->toDateTimeString()
+            ]);
+
+            return response()->json([
+                'success' => false,
+                'message' => 'Leadership Chaque Match cron job failed: ' . $e->getMessage(),
+                'data' => null
+            ], 500);
+        }
+    }
+
+    /**
      * Get latest active package (API endpoint for LatestActivePackageCard.jsx)
      */
     public function getLatestActivePackage()

--- a/routes/web.php
+++ b/routes/web.php
@@ -917,6 +917,7 @@ Route::post('/join/{referral_code}', [RegisterController::class, 'register'])->n
 
 // Cron Routes
 Route::get('/cron/activate-member-package', [CronController::class, 'activateMemberPackage'])->name('cron.activate.member.package');
+Route::get('/cron/leadership-chaque-match', [CronController::class, 'cronLeadershipChaqueMatch'])->name('cron.leadership.chaque.match');
 Route::get('/api/latest-active-package', [CronController::class, 'getLatestActivePackage'])->name('api.latest.active.package');
 
 require __DIR__.'/auth.php';


### PR DESCRIPTION
Add `cron_leadership_chaque_match` to fetch specific order data for leadership chaque match processing and update documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-d9f91d81-79e2-42a1-9428-a8766c5f45cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d9f91d81-79e2-42a1-9428-a8766c5f45cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

